### PR TITLE
Back fix

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -36,7 +36,8 @@ def main():
 
 	while True:
 		response = raw_input('> ')
-
+                #remove ending whitespace
+                response = response.strip()
 		if response == 'help':
 			displayOptions()
 		elif response == '1':

--- a/Main.py
+++ b/Main.py
@@ -62,6 +62,8 @@ def main():
 					break
 				elif user_input == 'exit':
 					return
+                                elif user_input == 'back':
+                                        break
 				else:
 					while True:
 						groupID = user_input

--- a/Main.py
+++ b/Main.py
@@ -69,25 +69,28 @@ def main():
 						groupID = user_input
 						try:
 							viewMessages(base_url+'/groups/', groupID, users)
-							response = messagePrompt(groupID)
-							if response == None:
-								displayOptions()
-								break
-							elif response == 'like':
-								messageId = raw_input('Please enter messageID > ')
-								favoriteMessage(groupID, messageId)
-							elif response == 'unlike':
-								messageId = raw_input('Please enter messageID > ')
-								unfavoriteMessage(groupID, messageId)
-							elif response == 'back':
-								break ## Go back to menu level
-							elif response == 'exit':
-								return ## Exit out of entire program
-							elif response == 'refresh':
-								viewMessages(base_url+'groups/', groupID, users)
-							elif response:
-								sendMessageToGroup(response, groupID)
-						except:
+                                                except:
+                                                        print "Failed to load messages"
+                                                        break
+						response = messagePrompt(groupID)
+						if response == None:
+							displayOptions()
+							break
+						elif response == 'like':
+							messageId = raw_input('Please enter messageID > ')
+							favoriteMessage(groupID, messageId)
+						elif response == 'unlike':
+							messageId = raw_input('Please enter messageID > ')
+							unfavoriteMessage(groupID, messageId)
+						elif response == 'back':
+							break ## Go back to menu level
+						elif response == 'exit':
+							return ## Exit out of entire program
+						elif response == 'refresh':
+							viewMessages(base_url+'groups/', groupID, users)
+						elif response:
+							sendMessageToGroup(response, groupID)
+                                                else:
 							print "Invalid input."
 					if response == 'no':
 						break


### PR DESCRIPTION
Adding the option to break out of the group selection loop using the 'back' command. 

Altered control flow of the messaging loop. It will now try to load messages and break out of the loop if it fails to. 

Both of these were added to avoid an infinite loop when using 'back' (or any other invalid command) in the group selection loop.


This is a really neat tool! I'll be using it often hopefully. Cool how emoji's show up in the terminal as art.
